### PR TITLE
APIサーバーを立てる練習

### DIFF
--- a/ApiServerTest/test-api-server.go
+++ b/ApiServerTest/test-api-server.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RequestBody はリクエストボディの構造体を定義します
+type RequestBody struct {
+	Message string `json:"message"`
+	Data    int    `json:"data"`
+}
+
+func main() {
+	r := gin.Default()
+
+	// POST /post エンドポイントのハンドラ
+	r.POST("/post", func(c *gin.Context) {
+		var requestBody RequestBody
+
+		// リクエストボディを構造体にバインド
+		if err := c.BindJSON(&requestBody); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		// レスポンスボディを作成
+		response := gin.H{
+			"received_message": requestBody.Message,
+			"received_data":    requestBody.Data,
+			"status":           "ok",
+		}
+
+		// JSON 形式でレスポンスを返す
+		c.JSON(http.StatusOK, response)
+	})
+
+	// サーバーを起動
+	r.Run(":8080") // ポート番号は適宜変更
+}


### PR DESCRIPTION
APIサーバーを立てる練習

- ginを用いて、適当なPOSTリクエストを受け付け、適当なリクエストボディを返すAPIサーバを構築する。
- postmanで以下を確かめる。
  - リクエストを送れること
  - レスポンスを受け取れること